### PR TITLE
Don't show errors as new if they are simply moved within a file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import {
   getNewErrors,
   parseTypeScriptErrors,
   readTypeScriptErrorsFromFile,
+  getTotalErrorsCount,
   toHumanReadableText,
   writeTypeScriptErrorsToFile
 } from './util'
@@ -64,16 +65,19 @@ import { rmSync } from 'fs'
           oldErrors,
           parseTypeScriptErrors(message)
         )
-        const newErrorsCount =
-          newErrors.size === 0
-            ? '0 errors found'
-            : `${newErrors.size} error${newErrors.size > 1 ? 's' : ''} found`
+        const newErrorsCount = getTotalErrorsCount(newErrors)
+        const oldErrorsCount = getTotalErrorsCount(oldErrors)
 
-        console.error(`
+        const newErrorsCountMessage =
+          newErrorsCount === 0
+            ? '0 errors found'
+            : `${newErrorsCount} error${newErrorsCount > 1 ? 's' : ''} found`
+
+        console.error(`${newErrorsCount > 0 ? '\nNew errors found:' : ''}
 ${toHumanReadableText(newErrors)}
 
-${newErrorsCount}. ${oldErrors.size} error${
-          oldErrors.size > 1 ? 's' : ''
+${newErrorsCountMessage}. ${oldErrorsCount} error${
+          oldErrorsCount > 1 ? 's' : ''
         } already in baseline.`)
       }
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,10 +3,16 @@ import objectHash from 'object-hash'
 
 export interface ErrorInfo {
   code: string
-  column: number
   file: string
-  line: number
   message: string
+  count: number
+}
+
+// Hash just the error info, not the count so that we can easily 
+// modify the count independently
+const getErrorInfoHash = (errorInfo: ErrorInfo) => {
+  const { count, ...rest } = errorInfo
+  return objectHash(rest)
 }
 
 export const parseTypeScriptErrors = (
@@ -21,14 +27,19 @@ export const parseTypeScriptErrors = (
     const match = line.match(errorPattern)
     if (match) {
       const [, file, lineStr, columnStr, code, message] = match
-      const error: ErrorInfo = {
+      let error: ErrorInfo = {
         file,
-        line: parseInt(lineStr),
-        column: parseInt(columnStr),
         code,
-        message
+        message,
+        count: 1
       }
-      const key = objectHash(error)
+      const key = getErrorInfoHash(error)
+
+      const existingError = errors.get(key)
+      if (existingError) {
+        error = { ...existingError }
+        error.count += 1
+      }
       errors.set(key, error)
     }
   }
@@ -61,7 +72,10 @@ export const getNewErrors = (
   const result = new Map<string, ErrorInfo>()
 
   for (const [id, error] of newErrors) {
-    if (!oldErrors.has(id)) {
+    if (
+      !oldErrors.has(id) ||
+      (oldErrors.get(id)?.count ?? 0) < (newErrors.get(id)?.count ?? 0)
+    ) {
       result.set(id, error)
     }
   }
@@ -78,7 +92,7 @@ export const toHumanReadableText = (
     log += `File: ${error.file}\n`
     log += `Message: ${error.message}\n`
     log += `Code: ${error.code}\n`
-    log += `Location: Line ${error.line}, Column ${error.column}\n`
+    log += `Count of error type: ${error.count}\n`
     log += `Hash: ${key}\n\n`
   }
 
@@ -95,10 +109,9 @@ export const addHashToBaseline = (hash: string, filepath: string): void => {
 
   newErrors.set(hash, {
     code: '0000',
-    column: 0,
     file: '0000',
-    line: 0,
-    message: '0000'
+    message: '0000',
+    count: 1
   })
 
   writeTypeScriptErrorsToFile(newErrors, filepath)

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ export interface ErrorInfo {
   count: number
 }
 
-// Hash just the error info, not the count so that we can easily 
+// Hash just the error info, not the count so that we can easily
 // modify the count independently
 const getErrorInfoHash = (errorInfo: ErrorInfo) => {
   const { count, ...rest } = errorInfo
@@ -72,16 +72,23 @@ export const getNewErrors = (
   const result = new Map<string, ErrorInfo>()
 
   for (const [id, error] of newErrors) {
-    if (
-      !oldErrors.has(id) ||
-      (oldErrors.get(id)?.count ?? 0) < (newErrors.get(id)?.count ?? 0)
-    ) {
+    if (!oldErrors.has(id)) {
       result.set(id, error)
+    } else {
+      const oldErrCount = oldErrors.get(id)?.count ?? 0
+      const newErrCount = newErrors.get(id)?.count ?? 0
+      if (oldErrCount < newErrCount) {
+        const newErrors = { ...error, count: newErrCount - oldErrCount }
+        result.set(id, newErrors)
+      }
     }
   }
 
   return result
 }
+
+export const getTotalErrorsCount = (errorMap: Map<string, ErrorInfo>): number =>
+  [...errorMap.values()].reduce((sum, info) => sum + info.count, 0)
 
 export const toHumanReadableText = (
   errorMap: Map<string, ErrorInfo>
@@ -92,7 +99,7 @@ export const toHumanReadableText = (
     log += `File: ${error.file}\n`
     log += `Message: ${error.message}\n`
     log += `Code: ${error.code}\n`
-    log += `Count of error type: ${error.count}\n`
+    log += `Count of new errors: ${error.count}\n`
     log += `Hash: ${key}\n\n`
   }
 


### PR DESCRIPTION
This is an initial implementation to address the fact that errors should not be reported as new simply by being moved in a file. Closes https://github.com/TimMikeladze/tsc-baseline/issues/15

The way this pull request implements this is by replacing the location data (line and column) in the error info with the count of that type of error. The `count` value isn't included in the error hash and is checked independently.