### PR TITLE
Fix the NaN bug reported in issue 21

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ import { rmSync } from 'fs'
 ${toHumanReadableText(newErrors)}
 
 ${newErrorsCountMessage}. ${oldErrorsCount} error${
-          oldErrorsCount == 1 ? '' : 's'
+          oldErrorsCount === 1 ? '' : 's'
         } already in baseline.`)
 
         if (newErrorsCount > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,15 +69,13 @@ import { rmSync } from 'fs'
         const oldErrorsCount = getTotalErrorsCount(oldErrors)
 
         const newErrorsCountMessage =
-          newErrorsCount === 0
-            ? '0 errors found'
-            : `${newErrorsCount} error${newErrorsCount > 1 ? 's' : ''} found`
+          `${newErrorsCount} error${newErrorsCount == 1 ? '' : 's'} found`
 
         console.error(`${newErrorsCount > 0 ? '\nNew errors found:' : ''}
 ${toHumanReadableText(newErrors)}
 
 ${newErrorsCountMessage}. ${oldErrorsCount} error${
-          oldErrorsCount > 1 ? 's' : ''
+          oldErrorsCount == 1 ? '' : 's'
         } already in baseline.`)
 
         if (newErrorsCount > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,7 @@ import { rmSync } from 'fs'
         const oldErrorsCount = getTotalErrorsCount(oldErrors)
 
         const newErrorsCountMessage =
-          `${newErrorsCount} error${newErrorsCount == 1 ? '' : 's'} found`
+          `${newErrorsCount} new error${newErrorsCount === 1 ? '' : 's'} found`
 
         console.error(`${newErrorsCount > 0 ? '\nNew errors found:' : ''}
 ${toHumanReadableText(newErrors)}

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,7 +88,7 @@ export const getNewErrors = (
 }
 
 export const getTotalErrorsCount = (errorMap: Map<string, ErrorInfo>): number =>
-  [...errorMap.values()].reduce((sum, info) => sum + info.count, 0)
+  Array.from(errorMap.values()).reduce((sum, info) => sum + info.count, 0)
 
 export const toHumanReadableText = (
   errorMap: Map<string, ErrorInfo>

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,6 +88,10 @@ export const getNewErrors = (
 }
 
 export const getTotalErrorsCount = (errorMap: Map<string, ErrorInfo>): number =>
+  // NOTE: Previously, this was written with an array spread, but there was a bug
+  // with microbundle that was incorrectly compiling that (see: https://github.com/TimMikeladze/tsc-baseline/issues/21).
+  // Until that is resolved or the bundler is switched for this repo, this has been
+  // rewritten with Array.from
   Array.from(errorMap.values()).reduce((sum, info) => sum + info.count, 0)
 
 export const toHumanReadableText = (


### PR DESCRIPTION
This fixes #21 .

I really don't know why the compiler wanted to convert the TypeScript code the wrong way, but using `Array.from` instead of the spread operator and the array initializer seemed to work properly in my tests.

While I was at it, I fixed up the pluralization logic, but if that's getting off topic, I can yank that commit.

What do you think?