### PR TITLE
Add option to ignore error messages and just track errors by type

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -126,6 +126,8 @@ describe('End-to-end tests', () => {
       Options:
         -p --path <path>  Path to file to save baseline errors to. Defaults to
                           .tsc-baseline.json
+        --ignoreMessages  Ignores specific type error messages and only counts errors
+                          by code.
         -h, --help        display help for command
 
       Commands:
@@ -150,13 +152,14 @@ describe('End-to-end tests', () => {
       expect(fs.existsSync(getBaselinePath())).toBe(true)
       expect(fs.readFileSync(getBaselinePath(), 'utf-8'))
         .toMatchInlineSnapshot(`
-        "{
-          \\"meta\\": {
-            \\"baselineFileVersion\\": 1
-          },
-          \\"errors\\": {}
-        }"
-      `)
+          "{
+            \\"meta\\": {
+              \\"baselineFileVersion\\": 1,
+              \\"ignoreMessages\\": false
+            },
+            \\"errors\\": {}
+          }"
+        `)
     })
 
     it('saves errors on separate lines so that it works well with version control', async () => {
@@ -164,17 +167,40 @@ describe('End-to-end tests', () => {
       expect(saveOutput.code).toBe(0)
       expect(fs.existsSync(getBaselinePath())).toBe(true)
       const baselineFileContent = fs.readFileSync(getBaselinePath(), 'utf-8')
-      expect(baselineFileContent.split('\n').length).toBeGreaterThan(1)
+      expect(baselineFileContent.split('\n').length).toBeGreaterThan(6)
       expect(baselineFileContent).toMatchInlineSnapshot(`
         "{
           \\"meta\\": {
-            \\"baselineFileVersion\\": 1
+            \\"baselineFileVersion\\": 1,
+            \\"ignoreMessages\\": false
           },
           \\"errors\\": {
             \\"74fbc5bc3645b575167c6eca966b224014ff7e42\\": {
               \\"file\\": \\"src/util.ts\\",
               \\"code\\": \\"TS2322\\",
-              \\"message\\": \\"Type 'number' is not assignable to type 'string'.\\",
+              \\"count\\": 1,
+              \\"message\\": \\"Type 'number' is not assignable to type 'string'.\\"
+            }
+          }
+        }"
+      `)
+    })
+
+    it('properly handles a flag to ignore error messages', async () => {
+      const saveOutput = await cli('save --ignoreMessages', basicTsErrorOutput)
+      expect(saveOutput.code).toBe(0)
+      expect(fs.existsSync(getBaselinePath())).toBe(true)
+      const baselineFileContent = fs.readFileSync(getBaselinePath(), 'utf-8')
+      expect(baselineFileContent).toMatchInlineSnapshot(`
+        "{
+          \\"meta\\": {
+            \\"baselineFileVersion\\": 1,
+            \\"ignoreMessages\\": true
+          },
+          \\"errors\\": {
+            \\"4ea57c4c703d8b1df2807230c82ed3a0610c013f\\": {
+              \\"file\\": \\"src/util.ts\\",
+              \\"code\\": \\"TS2322\\",
               \\"count\\": 1
             }
           }
@@ -252,59 +278,111 @@ describe('End-to-end tests', () => {
       `)
     })
 
-    it('gives a helpful error if no baseline file is found', async () => {
-      const checkOutput = await cli('check', ' ')
+    describe('baseline file validation', () => {
+      it('gives a helpful error if no baseline file is found', async () => {
+        const checkOutput = await cli('check', ' ')
 
-      expect(checkOutput.code).toBe(1)
-      expect(checkOutput.stderr).toMatch(
-        new RegExp(
-          `Unable to read the .tsc-baseline.json file at "${getBaselinePath()}".`
+        expect(checkOutput.code).toBe(1)
+        expect(checkOutput.stderr).toMatch(
+          new RegExp(
+            `Unable to read the .tsc-baseline.json file at "${getBaselinePath()}".`
+          )
         )
-      )
-      expect(checkOutput.stderr).toMatch(
-        /Has the baseline file been properly saved with the 'save' command\?/
-      )
+        expect(checkOutput.stderr).toMatch(
+          /Has the baseline file been properly saved with the 'save' command\?/
+        )
+      })
+
+      it('fails if using an earlier version of the baseline errors file that does not have metadata', async () => {
+        fs.writeFileSync(getBaselinePath(), '{}')
+
+        const checkOutput = await cli('check', ' ')
+
+        expect(checkOutput.code).toBe(1)
+        expect(checkOutput.stderr).toMatch(
+          new RegExp(
+            `The .tsc-baseline.json file at "${getBaselinePath()}"\nis out of date for this version of tsc-baseline.`
+          )
+        )
+        expect(checkOutput.stderr).toMatch(
+          /Please update the baseline file using the 'save' command./
+        )
+      })
+
+      it('warns about being the wrong package version if the baseline file version is a future version', async () => {
+        fs.writeFileSync(
+          getBaselinePath(),
+          JSON.stringify(
+            {
+              meta: { baselineFileVersion: 10000, ignoreMessages: false },
+              errors: {}
+            },
+            null,
+            2
+          )
+        )
+        const checkOutput = await cli('check', ' ')
+
+        expect(checkOutput.code).toBe(1)
+        expect(checkOutput.stderr).toMatch(
+          new RegExp(
+            `The .tsc-baseline.json file at "${getBaselinePath()}"\nis from a future version of tsc-baseline.`
+          )
+        )
+        expect(checkOutput.stderr).toMatch(
+          /Are your installed packages up to date\?/
+        )
+      })
     })
 
-    it('fails if using an earlier version of the baseline errors file that does not have metadata', async () => {
-      fs.writeFileSync(getBaselinePath(), '{}')
+    describe('--ignoreMessages flag', () => {
+      it('does not show errors if all the errors already exist', async () => {
+        await cli('save --ignoreMessages', basicTsErrorOutput)
+        const checkOutput = await cli('check', basicTsErrorOutput)
+        // expect(checkOutput.code).toBe(0)
+        expect(checkOutput.stderr).toMatchInlineSnapshot(`
+          "
 
-      const checkOutput = await cli('check', ' ')
 
-      expect(checkOutput.code).toBe(1)
-      expect(checkOutput.stderr).toMatch(
-        new RegExp(
-          `The .tsc-baseline.json file at "${getBaselinePath()}"\nis out of date for this version of tsc-baseline.`
-        )
-      )
-      expect(checkOutput.stderr).toMatch(
-        /Please update the baseline file using the 'save' command./
-      )
-    })
+          0 new errors found. 1 error already in baseline.
+          "
+        `)
+      })
 
-    it('warns about being the wrong package version if the baseline file version is a future version', async () => {
-      fs.writeFileSync(
-        getBaselinePath(),
-        JSON.stringify(
-          {
-            meta: { baselineFileVersion: 10000 },
-            errors: {}
-          },
-          null,
-          2
-        )
-      )
-      const checkOutput = await cli('check', ' ')
+      it('only shows all potentially new errors', async () => {
+        const originalErrors = removeIndent`
+          > tsc-baseline@1.4.0 type-check
+          > tsc
+  
+          src/util.ts(13,17): error TS2322: Type 'number' is not assignable to type 'string'.
+        `
+        await cli('save --ignoreMessages', originalErrors)
 
-      expect(checkOutput.code).toBe(1)
-      expect(checkOutput.stderr).toMatch(
-        new RegExp(
-          `The .tsc-baseline.json file at "${getBaselinePath()}"\nis from a future version of tsc-baseline.`
-        )
-      )
-      expect(checkOutput.stderr).toMatch(
-        /Are your installed packages up to date\?/
-      )
+        const newErrors = removeIndent`
+          > tsc-baseline@1.4.0 type-check
+          > tsc
+  
+          src/util.ts(133,7): error TS2322: Type 'number' is not assignable to type 'string'.
+          src/util.ts(135,7): error TS2322: Type '{ invalid: number; }' is not assignable to type 'number'.
+        `
+        const checkOutput = await cli('check', newErrors)
+
+        expect(checkOutput.code).toBe(1)
+        expect(checkOutput.stderr).toMatchInlineSnapshot(`
+          "
+          New errors found:
+          File: src/util.ts
+          Code: TS2322
+          Hash: 4ea57c4c703d8b1df2807230c82ed3a0610c013f
+          Count of new errors: 1
+          2 current errors:
+          src/util.ts(133,7)
+          src/util.ts(135,7)
+
+          1 new error found. 1 error already in baseline.
+          "
+        `)
+      })
     })
   })
 })

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -43,8 +43,10 @@ src/util.ts(81,1): error TS1128: Declaration or statement expected.
 src/somethingElse.ts(2,1): error TS1128: Declaration or statement expected.
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`
 
-    const { specificErrorsMap, errorSummaryMap } =
-      parseTypeScriptErrors(errorLog)
+    const { specificErrorsMap, errorSummaryMap } = parseTypeScriptErrors(
+      errorLog,
+      { ignoreMessages: false }
+    )
 
     expect(specificErrorsMap.size).toBe(2)
     const utilFileErrors = specificErrorsMap.get('src/util.ts')
@@ -85,13 +87,14 @@ info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
     })
 
     const filePath = resolve(tempDir, 'test-errors.json')
-    writeTypeScriptErrorsToFile(errorMap, filePath)
+    writeTypeScriptErrorsToFile(errorMap, filePath, { ignoreMessages: false })
 
     const fileContent = fs.readFileSync(filePath, 'utf-8')
     const parsedContent = JSON.parse(fileContent)
     expect(parsedContent).toEqual({
       meta: {
-        baselineFileVersion: 1
+        baselineFileVersion: 1,
+        ignoreMessages: false
       },
       errors: {
         '8d4f5b0a6c282e236e4f437a50410d72': {
@@ -123,7 +126,8 @@ info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
       JSON.stringify(
         {
           meta: {
-            baselineFileVersion: 1
+            baselineFileVersion: 1,
+            ignoreMessages: false
           },
           errors: {
             '8d4f5b0a6c282e236e4f437a50410d72': {
@@ -374,7 +378,9 @@ Count of new errors: 1
 file2.ts(5,6)
     `.trim() // Remove leading newline
 
-    const result = toHumanReadableText(errorSummaryMap, specificErrorsMap)
+    const result = toHumanReadableText(errorSummaryMap, specificErrorsMap, {
+      ignoreMessages: false
+    })
     expect(result).toBe(expectedOutput)
   })
 
@@ -388,7 +394,7 @@ file2.ts(5,6)
     })
 
     const filePath = resolve(tempDir, 'test-errors.json')
-    writeTypeScriptErrorsToFile(errorMap, filePath)
+    writeTypeScriptErrorsToFile(errorMap, filePath, { ignoreMessages: false })
 
     addHashToBaseline('hash1234', filePath)
 
@@ -396,7 +402,8 @@ file2.ts(5,6)
     const parsedContent = JSON.parse(fileContent)
     expect(parsedContent).toEqual({
       meta: {
-        baselineFileVersion: 1
+        baselineFileVersion: 1,
+        ignoreMessages: false
       },
       errors: {
         '8d4f5b0a6c282e236e4f437a50410d72': {
@@ -427,7 +434,10 @@ src/util.ts(43,1): error TS1128: Declaration or statement expected.
 src/util.ts(81,1): error TS1128: Declaration or statement expected.
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`
 
-    const originalErrorsParsingResult = parseTypeScriptErrors(originalErrorLog)
+    const originalErrorsParsingResult = parseTypeScriptErrors(
+      originalErrorLog,
+      { ignoreMessages: false }
+    )
 
     const newErrorLog = `warning package.json: License should be a valid SPDX license expression
 error Command failed with exit code 2.
@@ -440,7 +450,9 @@ src/util.ts(43,1): error TS1128: Declaration or statement expected.
 src/util.ts(181,1): error TS1128: Declaration or statement expected.
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`
 
-    const newErrorsParsingResult = parseTypeScriptErrors(newErrorLog)
+    const newErrorsParsingResult = parseTypeScriptErrors(newErrorLog, {
+      ignoreMessages: false
+    })
 
     const newErrors = getNewErrors(
       originalErrorsParsingResult.errorSummaryMap,
@@ -459,7 +471,10 @@ src/util.ts(35,12): error TS1389: 'if' is not allowed as a variable declaration 
 src/util.ts(40,3): error TS1128: Declaration or statement expected.
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`
 
-    const originalErrorsParsingResult = parseTypeScriptErrors(originalErrorLog)
+    const originalErrorsParsingResult = parseTypeScriptErrors(
+      originalErrorLog,
+      { ignoreMessages: false }
+    )
 
     const newErrorLog = `warning package.json: License should be a valid SPDX license expression
 error Command failed with exit code 2.
@@ -472,7 +487,9 @@ src/util.ts(43,1): error TS1128: Declaration or statement expected.
 src/util.ts(181,1): error TS1128: Declaration or statement expected.
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.`
 
-    const newErrorsParsingResult = parseTypeScriptErrors(newErrorLog)
+    const newErrorsParsingResult = parseTypeScriptErrors(newErrorLog, {
+      ignoreMessages: false
+    })
 
     const newErrors = getNewErrors(
       originalErrorsParsingResult.errorSummaryMap,


### PR DESCRIPTION
This pull request:
- Changes the file format of the baseline and adds a version number and associated version logic. Closes #24 
- Provides validation that the baseline error file exists when running `check`. Closes #22 
- Implements a new optional flag for the `check` command `--ignoreMessages` which causes errors to only be tracked by count and type per file, not the actual description as well. Closes #31 