### PR TITLE
feat: add new option reportUnmatchedIgnoredErrors

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -217,7 +217,8 @@ export const getTotalErrorsCount = (errorMap: ErrorSummaryMap): number =>
 export const toHumanReadableText = (
   errorSummaryMap: ErrorSummaryMap,
   specificErrorMap: SpecificErrorsMap,
-  errorOptions: ErrorOptions
+  errorOptions: ErrorOptions,
+  isReportingUnmatchedErrors = false
 ): string => {
   let log = ''
 
@@ -234,17 +235,20 @@ export const toHumanReadableText = (
     }
     log += `Code: ${error.code}\n`
     log += `Hash: ${key}\n`
-    log += `Count of new errors: ${error.count}\n`
-    log += `${specificErrors.length} current error${
-      specificErrors.length === 1 ? '' : 's'
-    }:\n`
 
-    log += specificErrors
-      .map(
-        (specificError) =>
-          `${specificError.file}(${specificError.line},${specificError.column})`
-      )
-      .join('\n')
+    if (!isReportingUnmatchedErrors) {
+      log += `Count of new errors: ${error.count}\n`
+      log += `${specificErrors.length} current error${
+        specificErrors.length === 1 ? '' : 's'
+      }:\n`
+
+      log += specificErrors
+        .map(
+          (specificError) =>
+            `${specificError.file}(${specificError.line},${specificError.column})`
+        )
+        .join('\n')
+    }
 
     log += '\n\n'
   }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -442,7 +442,11 @@ file2.ts(5,6)
       ]
     ])
 
-    const result: GitLabErrorFormat[] = JSON.parse(toGitLabOutputFormat(errorSummaryMap, specificErrorsMap, { ignoreMessages: false }))
+    const result: GitLabErrorFormat[] = JSON.parse(
+      toGitLabOutputFormat(errorSummaryMap, specificErrorsMap, {
+        ignoreMessages: false
+      })
+    )
 
     expect(result).toEqual<GitLabErrorFormat[]>([
       {


### PR DESCRIPTION
There is an open issue which forces the user to rebaseline the known errors when something gets fixed or removed. This helps avoiding the reintroducing of already fixed errors. Long term wise the code quality (or TSC) will reduce over the long term similar like in PHPStan

Here is the issue:
https://github.com/TimMikeladze/tsc-baseline/issues/26